### PR TITLE
Refactors cursor installation to unpacked appimage

### DIFF
--- a/app/installations/essential/cursor.sh
+++ b/app/installations/essential/cursor.sh
@@ -1,6 +1,88 @@
-install_package "cursor-bin" aur
+#!/bin/bash
 
-if [ ! -d ~/.config/Code\ -\ OSS/User ]; then
-    mkdir -p ~/.config/Code\ -\ OSS/User
-    cp "$MANJIKAZE_DIR/configs/code.json" ~/.config/Code\ -\ OSS/User/settings.json
+# This script installs Cursor by extracting an AppImage rather than using the AUR package (cursor-bin).
+# Benefits of this approach:
+# - Fixes mise-en-place integration in the terminal (the AppImage sandbox breaks this)
+# - Makes updates more reliable and controlled through our system
+# - Allows for better version detection and management
+# - Minimizes sandbox-related permission issues
+
+get_cursor_download_url() {
+    local download_url=$(curl -s "https://www.cursor.com/api/download?platform=linux-x64&releaseTrack=latest" | jq -r '.downloadUrl')
+
+    if [[ -z "$download_url" ]]; then
+        status "Failed to get Cursor download URL."
+        exit 1
+    fi
+
+    echo "$download_url"
+}
+
+get_cursor_installed_version() {
+    local package_json=~/.local/share/cursor/usr/share/cursor/resources/app/package.json
+
+    if [[ -f "$package_json" ]]; then
+        local installed_version=$(jq -r '.version' "$package_json" 2>/dev/null)
+        echo "$installed_version"
+    else
+        echo ""
+    fi
+}
+
+download_cursor_appimage() {
+    local download_url="$1"
+    local output_file="${2:-/tmp/cursor.AppImage}"
+
+    status "Downloading Cursor AppImage..."
+    curl -s -L "$download_url" -o "$output_file"
+    chmod +x "$output_file"
+}
+
+install_cursor_from_appimage() {
+    local appimage_path="${1:-/tmp/cursor.AppImage}"
+
+    mkdir -p ~/.local/share/applications
+    mkdir -p ~/.local/bin
+    mkdir -p ~/.local/share/cursor
+
+    status "Extracting AppImage..."
+    cd /tmp
+    "$appimage_path" --appimage-extract
+    rm -f "$appimage_path"
+
+    status "Installing Cursor..."
+    rm -rf ~/.local/share/cursor/* || true
+    mv /tmp/squashfs-root/* ~/.local/share/cursor/
+
+    rm -f ~/.local/bin/cursor || true
+    ln -sf ~/.local/share/cursor/usr/bin/cursor ~/.local/bin/cursor
+
+    cat > ~/.local/share/applications/cursor.desktop << EOL
+[Desktop Entry]
+Name=Cursor
+Comment=AI-first code editor
+Exec=cursor
+Icon=/home/$USER/.local/share/cursor/code.png
+Type=Application
+StartupNotify=true
+Categories=Development;
+EOL
+
+    chmod +x ~/.local/share/applications/cursor.desktop
+}
+
+install_cursor() {
+    status "Installing Cursor from extracted AppImage..."
+
+    local download_url=$(get_cursor_download_url)
+    download_cursor_appimage "$download_url"
+    install_cursor_from_appimage
+    create_cursor_desktop_entry
+
+    status "Package 'cursor' installed successfully."
+}
+
+# If this script is being sourced, don't run the installation
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    install_cursor
 fi

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -10,7 +10,8 @@ This section documents the various features and capabilities of Manjikaze.
 - [Shell Tools](shell-tools.md) - Command-line utilities and tools
 - [GUIs](gui.md) - Graphical applications and utilities
 - [Runtimes](mise-runtime-manager.md) - Language runtimes and package managers
-- [AWS tools](aws-tools.md) - AWS CLI and AWS Vault configuration
+- [AWS Tools](aws-tools.md) - AWS CLI and AWS Vault configuration
+- [Cursor Installation](cursor-installation.md) - Cursor AI-editor installation
 
 ---
 

--- a/docs/features/aws-tools.md
+++ b/docs/features/aws-tools.md
@@ -91,4 +91,4 @@ For more detailed information about AWS Vault, refer to the [official GitHub rep
 
 ---
 
-[← Runtimes](mise-runtime-manager.md) | [Documentation Home](../README.md)
+[← Runtimes](mise-runtime-manager.md) | [Cursor Installation →](cursor-installation.md)

--- a/docs/features/cursor-installation.md
+++ b/docs/features/cursor-installation.md
@@ -1,0 +1,54 @@
+# Cursor Installation
+
+## Overview
+
+Manjikaze installs [Cursor](https://cursor.sh/) (an AI-powered code editor) using an extracted AppImage approach rather than the traditional AUR package installation. This document explains the rationale behind this decision and the benefits it provides.
+
+## Installation Method
+
+Instead of installing Cursor using `cursor-bin` from the AUR, Manjikaze:
+
+1. Downloads the latest Cursor AppImage from the official source
+2. Extracts the AppImage contents to `~/.local/share/cursor/`
+3. Creates a symlink at `~/.local/bin/cursor`
+4. Sets up a proper desktop entry for integration with the system
+
+## Benefits
+
+### 1. Improved Terminal Integration
+
+The primary motivation for this approach is to fix issues with [mise-en-place](https://mise.jdx.dev/) integration in Cursor's integrated terminal. When Cursor runs inside an AppImage sandbox, it has limited access to the host environment, which can break tools like mise that rely on PATH extensions and shell integration.
+
+By extracting the AppImage, Cursor runs directly on the host system without these sandbox limitations, allowing the integrated terminal to properly access and use mise-managed tools and environments.
+
+### 2. Better Update Management
+
+This approach also allows Manjikaze to:
+- Detect the installed Cursor version more accurately (from its package.json)
+- Compare it with the latest available version
+- Provide seamless updates through the `manjikaze update` command
+
+## Migration
+
+If you previously installed Cursor through the AUR, Manjikaze provides a migration script to convert your installation to this optimized approach. The migration:
+
+1. Removes the AUR package
+2. Downloads and extracts the latest AppImage
+3. Sets up the proper desktop integration
+
+**Note:** This migration may result in the loss of some Cursor settings and chat history, as they're stored in different locations between installation methods.
+
+## Update
+
+The best approach to update Cursor is to use the `manjikaze update` command. This will update all installed applications, including Cursor. If you manually want to update Cursor ony, you can run the following:
+
+```bash
+cd ~/.manjikaze
+source lib/common.sh
+source app/installations/essential/cursor.sh
+install_cursor
+```
+
+---
+
+[← AWS Tools](aws-tools.md) | [Documentation Home](../README.md)

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 status() {
-    time=$(date +%T)
-    echo -e "\033[1;32m$time\033[0m - \033[0;32m$1\033[0m"
+    gum log --time "$(date +%T)" --structured --level info "$1"
 }
 
 get_version() {

--- a/migrations/1745053593_add_clipboard_extension.sh
+++ b/migrations/1745053593_add_clipboard_extension.sh
@@ -3,12 +3,12 @@ set -e
 
 if [[ "$XDG_CURRENT_DESKTOP" != *"GNOME"* ]]; then
     status "Skipping Clipboard Indicator extension installation as you are not running GNOME."
-    exit 0
+    return 0
 fi
 
 if gnome-extensions list | grep -q "clipboard-indicator@tudmotu.com"; then
     status "Clipboard indicator extension is already installed."
-    exit 0
+    return 0
 fi
 
 if gum confirm "Would you like to install the GNOME Clipboard Indicator extension?"; then

--- a/migrations/1747729923_extract_cursor_appimage.sh
+++ b/migrations/1747729923_extract_cursor_appimage.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+if ! command -v cursor &> /dev/null; then
+    status "Cursor is not installed. Skipping migration."
+    return 0
+fi
+
+if gum confirm $'Would you like to convert your Cursor installation to an extracted AppImage?\nNote: This could result in a loss of your chat history and settings.'; then
+    status "Removing existing Cursor installation..."
+    yay -Rns --noconfirm --noprogressbar cursor
+
+    status "Installing Cursor as an extracted AppImage..."
+    source "$MANJIKAZE_DIR/app/installations/essential/cursor.sh"
+
+    install_cursor
+fi


### PR DESCRIPTION
The AppImage installation of Cursor has several issues. The most notable is breaking mise-en-place in the integrated terminal. Breaking Cursor out of it's AppImage should resolve this issue.