### PR TITLE
Changes aws-cli installation to prebuild bin version

### DIFF
--- a/app/installations/essential/aws-cli.sh
+++ b/app/installations/essential/aws-cli.sh
@@ -1,2 +1,2 @@
-install_package "aws-cli-v2" aur
+install_package "aws-cli-bin" aur
 install_package "aws-sam-cli-bin" aur


### PR DESCRIPTION
With Python managed by mise-en-place, the installation of the AWS CLI that uses a linked Python runtime fails. Switching to a prebuild standalone version fixes this and is a more robust approach in general.