### PR TITLE
Adds Aws session manager as optional dependency

### DIFF
--- a/app/installations/install-optional-apps.sh
+++ b/app/installations/install-optional-apps.sh
@@ -1,6 +1,6 @@
 OPTIONAL_APPS=($(ls "$MANJIKAZE_DIR/app/installations/optional/"*.sh | xargs -n1 basename | sed 's/\.sh$//'))
 
-SELECTED_OPTIONAL_APPS=$(gum choose "${OPTIONAL_APPS[@]}" --no-limit --height 20 --header "Select optional apps" | tr ' ' '-')
+SELECTED_OPTIONAL_APPS=$(gum choose "${OPTIONAL_APPS[@]}" --no-limit --height 20 --header "Select optional apps" | tr ' ' '|')
 
 if [ -z "$SELECTED_OPTIONAL_APPS" ]; then
     status "No optional apps selected. Skipping installation."
@@ -8,7 +8,7 @@ if [ -z "$SELECTED_OPTIONAL_APPS" ]; then
 fi
 
 echo "The following optional apps will be installed:"
-printf "  - %s\n" ${SELECTED_OPTIONAL_APPS//-/ }
+printf "  - %s\n" ${SELECTED_OPTIONAL_APPS//|/ }
 
 if ! gum confirm "Do you want to proceed with the installation?"; then
     status "Optional apps installation cancelled."
@@ -18,7 +18,7 @@ fi
 status "Installing optional apps..."
 disable_sleep
 
-for app in ${SELECTED_OPTIONAL_APPS//-/ }; do
+for app in ${SELECTED_OPTIONAL_APPS//|/ }; do
     app_file="$MANJIKAZE_DIR/app/installations/optional/${app,,}.sh"
     if [ -f "$app_file" ]; then
         source "$app_file"

--- a/app/installations/optional/aws-session-manager-plugin.sh
+++ b/app/installations/optional/aws-session-manager-plugin.sh
@@ -1,0 +1,2 @@
+install_package "aws-session-manager-plugin" aur
+


### PR DESCRIPTION
Gebaseerd op https://github.com/10KB/manjikaze/pull/45. 

Dashes als splitter werkt niet voor package names met dashes