### PR TITLE
Fix error during durning yubikey-pam-authentication

### DIFF
--- a/app/security/yubikey/yubikey-pam-authentication.sh
+++ b/app/security/yubikey/yubikey-pam-authentication.sh
@@ -68,8 +68,6 @@ EOF
 
         sudo install -o root -g root -m 0440 "$tmp" /etc/sudoers.d/99-yubikey-prompt
         rm -f "$tmp"
-    else
-        status "Prompt already configured in /etc/pam.d/sudo."
     fi
 
     echo "PAM authentication with YubiKey has been configured for system-wide use."


### PR DESCRIPTION
Tijdens het instellen van 'Configure Yubikey as MFA for system' kreeg ik de foutmelding:

.manjikaze/app/security/yubikey/yubikey-pam-authentication.sh: line 71: syntax error near unexpected token `else'

Als ik deze regel weghaal dan werkt het script wel en ik kan nu ook inloggen met mijn ubikey en sudoen etc. 