### PR TITLE
Fixes mise node lts definition update and aur breezy dependency

### DIFF
--- a/app/installations/update-installed-apps.sh
+++ b/app/installations/update-installed-apps.sh
@@ -170,7 +170,14 @@ fi
 
 if [ "$aur_count" -gt 0 ]; then
     status "Updating AUR packages..."
-    yay -Sua --noconfirm --noprogressbar
+    # Ensure system tools like brz use system Python for building AUR packages
+    PATH=/usr/bin:$PATH yay -Sua --noconfirm --noprogressbar
+fi
+
+# Sync mise runtimes if mise is installed
+if command -v mise &>/dev/null; then
+    status "Syncing mise runtimes..."
+    mise install
 fi
 
 # Update Cursor if available

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -100,7 +100,8 @@ install_package() {
     local output
     if [[ "$type" == "aur" ]]; then
         status "Installing AUR package $package..."
-        output=$(yay -S "$package" --noconfirm --noprogressbar --quiet 2>&1)
+        # Ensure system tools use system Python for building AUR packages
+        output=$(PATH=/usr/bin:$PATH yay -S "$package" --noconfirm --noprogressbar --quiet 2>&1)
     else
         status "Installing repository package $package..."
         output=$(sudo pacman -S "$package" --noconfirm --noprogressbar --quiet 2>&1)

--- a/migrations/1765824824_install_breezy_for_mise.sh
+++ b/migrations/1765824824_install_breezy_for_mise.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+if ! command -v mise &> /dev/null; then
+    status "mise is not installed, skipping breezy installation."
+    return 0
+fi
+
+status "Installing breezy into mise Python environment..."
+status "This allows brz to work correctly for building AUR packages that use Launchpad sources."
+
+if mise exec python -- pip install breezy; then
+    status "breezy installed successfully."
+else
+    status "Warning: Failed to install breezy. Some AUR packages may fail to build."
+    status "You can try manually: mise exec python -- pip install breezy"
+fi
+

--- a/migrations/1765824825_sync_mise_runtimes.sh
+++ b/migrations/1765824825_sync_mise_runtimes.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+if ! command -v mise &> /dev/null; then
+    status "mise is not installed, skipping runtime sync."
+    return 0
+fi
+
+status "Syncing mise runtimes to ensure all configured versions are installed..."
+
+if mise install; then
+    status "mise runtimes synced successfully."
+else
+    status "Warning: Failed to sync mise runtimes. Run 'mise install' manually to fix."
+fi
+


### PR DESCRIPTION
2 fixes in 1 commit:

## 1. Node LTS install

In `mise.toml` staat `node` op `lts`. Sinds kort betekent dat node 24. Zolang je die niet dmv `mise install` versie 24 op je systeem geinstalleerd hebt, krijg je een warning bij het opstarten van een terminal:

```
mise WARN  missing: node@24.12.0
```

Hierin wordt het opgelost dmv zowel een migration als een ensure in update-installed-apps.sh

## 2. Breezy dependency voor AUR packages (o.a. libappindicator-gtk2)

AUR packages die vanaf Launchpad gebuild worden (zoals `libappindicator-gtk2` voor Dropbox) hebben `brz` (breezy) nodig. De `brz` binary is gelinked aan system Python, maar zoekt modules via `PATH`. Omdat mise Python vooraan komt in `PATH`, kan brz de breezy module niet vinden:

```
brz: ERROR: Couldn't import breezy and dependencies.
Please check the directory containing breezy is on your PYTHONPATH.

Error: PyErr { type: <class 'ModuleNotFoundError'>, value: ModuleNotFoundError("No module named 'breezy'"), traceback: None }
```

1. Met een migration installeren we breezy in mise Python.
2. In de `install_package` util zetten we voor yay commands nu `PATH=/usr/bin:$PATH` zodat system tools correct werken bij AUR builds
