### PR TITLE
Installs iptables-nft backend for modern kernels (6.17+)

### DIFF
--- a/app/installations/essential/docker.sh
+++ b/app/installations/essential/docker.sh
@@ -1,6 +1,6 @@
 install_docker() {
     status "Installing Docker..."
-    if ! sudo pamac install docker docker-buildx --no-confirm; then
+    if ! sudo pamac install docker docker-buildx iptables-nft --no-confirm; then
         status "Failed to install Docker packages."
         return 1
     fi


### PR DESCRIPTION
Na een update van Manjaro (specifiek bij gebruik van de nieuwere 6.17+ kernels) startte Docker niet meer op. De Docker daemon probeerde de legacy `ip_tables` kernelmodule te laden, maar deze is in de nieuwere kernels niet meer standaard aanwezig of geactiveerd. Dit geeft dan deze foutmelding:

```shell
modprobe: FATAL: Module ip_tables not found in directory /lib/modules/...
```

In plaats van de legacy `iptables` installeren we hier `iptables-nft`. Deze package geeft een backwards compatible `iptables` CLI voor Docker, en translate dit naar het nieuwere nftables subsysteem van de Linux kernel.
