### PR TITLE
Scopes the sudo keep-alive loop to automated operations only

### DIFF
--- a/bin/manjikaze
+++ b/bin/manjikaze
@@ -92,13 +92,16 @@ show_header() {
 }
 
 main() {
+    # Ensure the sudo keep-alive is always cleaned up, even on unexpected exit.
+    trap 'stop_sudo_keepalive' EXIT
+
     if [[ "$1" == "update" ]]; then
         clear
         show_header
 
         status "Requesting administrator privileges for system commands..."
         sudo -v
-        (while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &)
+        start_sudo_keepalive
 
         # First update manjikaze itself
         check_updates "$@"
@@ -116,7 +119,7 @@ main() {
 
     status "Requesting administrator privileges for system commands..."
     sudo -v
-    (while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &)
+    start_sudo_keepalive
 
     check_updates "$@"
 
@@ -126,6 +129,9 @@ main() {
 
     run_audits || status "Audit check/run finished with errors or cancellation."
 
+    # Stop the keep-alive before entering the interactive menu.
+    stop_sudo_keepalive
+
     clear
     show_header
 
@@ -133,3 +139,4 @@ main() {
 }
 
 main "$@"
+

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -28,6 +28,22 @@ enable_sleep() {
     fi
 }
 
+start_sudo_keepalive() {
+    if [[ -n "${_SUDO_KEEPALIVE_PID:-}" ]] && kill -0 "$_SUDO_KEEPALIVE_PID" 2>/dev/null; then
+        return 0 # Already running
+    fi
+    while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+    _SUDO_KEEPALIVE_PID=$!
+}
+
+stop_sudo_keepalive() {
+    if [[ -n "${_SUDO_KEEPALIVE_PID:-}" ]]; then
+        kill "$_SUDO_KEEPALIVE_PID" 2>/dev/null || true
+        wait "$_SUDO_KEEPALIVE_PID" 2>/dev/null || true
+        unset _SUDO_KEEPALIVE_PID
+    fi
+}
+
 activate_zsh_plugin() {
     local plugin="$1"
     local zshrc="$HOME/.zshrc"


### PR DESCRIPTION
The `manjikaze` script uses a background loop that refreshes the sudo timestamp every 60 seconds, keeping root access alive without re-prompting. This is necessary because a fresh install or system update can take >5 minutes, exceeding sudo's default timeout.

The problem with the current implementation is that this loop runs for the entire manjikaze session. Including the interactive menu, where the user may spend an extended period browsing options. During that time, any subprocess (or rogue process in the same session) effectively has passwordless root access.

This PR changes:
The keep-alive loop has been extracted into `start_sudo_keepalive` and `stop_sudo_keepalive` helpers in. In `manjikaze`, the keep-alive is now:

- Started after `sudo -v` (the initial authentication prompt)
- Stopped before `handle_menu` (the interactive menu)
- Cleaned up on exit via an `EXIT` trap

This means the privileged window is limited to exactly the operations that need it (updates, prerequisite installation, migrations, audits) and does not extend into interactive use.

On the `manjikaze update` path the keep-alive runs for the full operation and is cleaned up when the script exits, which is acceptable since that path is fully automated with no interactive menu.