### PR TITLE
Add optional DisplayLink installation

### DIFF
--- a/app/installations/optional/displaylink.sh
+++ b/app/installations/optional/displaylink.sh
@@ -1,0 +1,18 @@
+install() {
+    install_package "displaylink" aur
+
+    local kernel_short=$(kernel_version_short)
+    install_package "linux${kernel_short}-headers" repo
+}
+
+uninstall() {
+    uninstall_package "displaylink" aur
+
+    local kernel_short=$(kernel_version_short)
+    uninstall_package "linux${kernel_short}-headers" repo
+}
+
+kernel_version_short() {
+    local kernel_version=$(uname -r) # e.g. 6.12.77-1-MANJARO
+    echo "$kernel_version" | grep -oP '^\d+\.\d+' | tr -d '.' # e.g. 612
+}

--- a/app/installations/optional/displaylink.sh
+++ b/app/installations/optional/displaylink.sh
@@ -3,9 +3,15 @@ install() {
 
     local kernel_short=$(kernel_version_short)
     install_package "linux${kernel_short}-headers" repo
+
+    sudo systemctl enable displaylink.service
+    sudo systemctl start displaylink.service
 }
 
 uninstall() {
+    sudo systemctl stop displaylink.service
+    sudo systemctl disable displaylink.service
+
     uninstall_package "displaylink" aur
 
     local kernel_short=$(kernel_version_short)


### PR DESCRIPTION
Om een Wavlink USB-C dock te kunnen gebruiken hebben we op linux twee packages nodig:
- `displaylink`
- `evdi`, inbegrepen in linux-headers.

De exacte commando's die ik heb gebruikt om het te installeren en te laten werken zijn:
```
yay -S displaylink
uname -r # 6.12.77-1-MANJARO
sudo pacman -S linux612-headers
sudo systemctl start displaylink.service
```

Als het goed is dekt deze installer de belangrijkste twee. Moeten collega's alleen nog zelf uitvogelen dat ze m handmatig moeten starten en afsluiten.